### PR TITLE
Only include .h and .swift files in 'source_files'

### DIFF
--- a/WeekdayPicker.podspec
+++ b/WeekdayPicker.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
 
-  s.source_files = 'Source/**/*'
+  s.source_files = 'Source/**/*.{h,swift}'
 end


### PR DESCRIPTION
This fixes the error
`
error: Multiple commands produce '/...../Build/Products/Debug-iphoneos/WeekdayPicker/WeekdayPicker.framework/Info.plist':
`
by only including real source files into the pod.